### PR TITLE
Switch to VerusCoin, verusd & VRSC.conf.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test-log
 lwd-api.html
 *.orig
 __debug_bin
+.vscode

--- a/README.md
+++ b/README.md
@@ -17,15 +17,11 @@ The Lightwalletd Server is experimental and a work in progress. Use it at your o
 
 # Overview
 
-[lightwalletd](https://github.com/asherda/lightwalletd) is a backend service that provides a bandwidth-efficient interface to the Zcash blockchain. Currently, lightwalletd supports the Sapling protocol version as its primary concern. The intended purpose of lightwalletd is to support the development of mobile-friendly shielded light wallets.
+[lightwalletd](https://github.com/asherda/lightwalletd) is a backend service that provides a bandwidth-efficient interface to the VerusCoin blockchain. Currently, lightwalletd supports the Sapling protocol version as its primary concern. The intended purpose of lightwalletd is to support the development of mobile-friendly shielded light wallets. The VerusCOin developers are porting this to the VerusCoin VRSC chain now. This version uses verusd rather than zcashd, but still has the old zcashd hashing support so it does not work yet. It thinks we are stuck at a reord immediately. Next PR should fix that and get lightwalletd working properly against VerusCoin's VESC chain using verusd.
 
 lightwalletd is a backend service that provides a bandwidth-efficient interface to the Zcash blockchain for mobile and other wallets, such as [Zecwallet](https://github.com/adityapk00/zecwallet-lite-lib).
 
 Lightwalletd has not yet undergone audits or been subject to rigorous testing. It lacks some affordances necessary for production-level reliability. We do not recommend using it to handle customer funds at this time (April 2020).
-
-To view status of [CI pipeline](https://gitlab.com/zcash/lightwalletd/pipelines)
-
-To view detailed [Codecov](https://codecov.io/gh/zcash/lightwalletd) report
 
 Documentation for lightwalletd clients (the gRPC interface) is in `docs/rtd/index.html`. The current version of this file corresponds to the two `.proto` files; if you change these files, please regenerate the documentation by running `make doc`, which requires docker to be installed. 
 # Local/Developer docker-compose Usage
@@ -36,7 +32,7 @@ Documentation for lightwalletd clients (the gRPC interface) is in `docs/rtd/inde
 
 ## Zcashd
 
-You must start a local instance of `zcashd`, and its `.zcash/zcash.conf` file must include the following entries
+You must start a local instance of `verusd`, and its `.komodo/VRSC.conf` file must include the following entries
 (set the user and password strings accordingly):
 ```
 txindex=1
@@ -46,17 +42,18 @@ rpcuser=xxxxx
 rpcpassword=xxxxx
 ```
 
-The `zcashd` can be configured to run `mainnet` or `testnet` (or `regtest`). If you stop `zcashd` and restart it on a different network (switch from `testnet` to `mainnet`, for example), you must also stop and restart lightwalletd.
+The `verusd` can be configured to run `mainnet` or `testnet` (or `regtest`). If you stop `verusd` and restart it on a different network (switch from `testnet` to `mainnet`, for example), you must also stop and restart lightwalletd.
 
-It's necessary to run `zcashd --reindex` one time for these options to take effect. This typically takes several hours, and requires more space in the `.zcash` data directory.
+It's necessary to run `verusd --reindex` one time for these options to take effect. This typically takes several hours, and requires more space in the `.komodo` data directory.
 
-Lightwalletd uses the following `zcashd` RPCs:
+Lightwalletd uses the following `verusd` RPCs:
 - `getblockchaininfo`
 - `getblock`
 - `getrawtransaction`
 - `getaddresstxids`
 - `sendrawtransaction`
 
+We pan on extending it to include identity and token options now that those are available (identity) or becoming available (tokens in may 2020).
 ## Lightwalletd
 
 First, install [Go](https://golang.org/dl/#stable) version 1.11 or later. You can see your current version by running `go version`.
@@ -69,10 +66,11 @@ your `$GOPATH` (`$HOME/go` by default), then build the lightwalletd server binar
 Assuming you used `make` to build the server, here's a typical developer invocation:
 
 ```
-./lightwalletd --no-tls-very-insecure --conf-file ~/.zcash/zcash.conf --data-dir . --log-file /dev/stdout
+"--log-file", "/logs/server.log", "--grpc-bind-addr", "127.0.0.1:18232", "--no-tls-very-insecure", "--verusd-conf-path", "/home/virtualsoundnw/.komodo/VRSC/VRSC.conf", "--data-dir", "~"
 ```
 Type `./lightwalletd help` to see the full list of options and arguments.
 
+Note that the --zcash-conf-path option is still listed but it doesn't do anything at the moment.
 # Production Usage
 
 Run a local instance of `zcashd` (see above), except do _not_ specify `--no-tls-very-insecure`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,7 @@ var rootCmd = &cobra.Command{
 			LogLevel:          viper.GetUint64("log-level"),
 			LogFile:           viper.GetString("log-file"),
 			ZcashConfPath:     viper.GetString("zcash-conf-path"),
+			VerusdConfPath:    viper.GetString("verusd-conf-path"),
 			NoTLSVeryInsecure: viper.GetBool("no-tls-very-insecure"),
 			DataDir:           viper.GetString("data-dir"),
 			Redownload:        viper.GetBool("redownload"),
@@ -62,7 +63,7 @@ var rootCmd = &cobra.Command{
 			os.OpenFile(opts.LogFile, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 		}
 		if !opts.Darkside {
-			filesThatShouldExist = append(filesThatShouldExist, opts.ZcashConfPath)
+			filesThatShouldExist = append(filesThatShouldExist, opts.VerusdConfPath)
 		}
 
 		for _, filename := range filesThatShouldExist {
@@ -165,11 +166,11 @@ func startServer(opts *common.Options) error {
 	if opts.Darkside {
 		common.RawRequest = common.DarkSideRawRequest
 	} else {
-		rpcClient, err := frontend.NewZRPCFromConf(opts.ZcashConfPath)
+		rpcClient, err := frontend.NewVRPCFromConf(opts.VerusdConfPath)
 		if err != nil {
 			common.Log.WithFields(logrus.Fields{
 				"error": err,
-			}).Fatal("setting up RPC connection to zcashd")
+			}).Fatal("setting up RPC connection to verusd")
 		}
 		// Indirect function for test mocking (so unit tests can talk to stub functions).
 		common.RawRequest = rpcClient.RawRequest
@@ -265,7 +266,8 @@ func init() {
 	rootCmd.Flags().String("tls-key", "./cert.key", "the path to a TLS key file")
 	rootCmd.Flags().Int("log-level", int(logrus.InfoLevel), "log level (logrus 1-7)")
 	rootCmd.Flags().String("log-file", "./server.log", "log file to write to")
-	rootCmd.Flags().String("zcash-conf-path", "./zcash.conf", "conf file to pull RPC creds from")
+	rootCmd.Flags().String("verusd-conf-path", "./verusd.conf", "conf file to pull VRSC RPC creds from")
+	rootCmd.Flags().String("zcash-conf-path", "./zcash.conf", "conf file to pull ZCash RPC creds from, not supported as we switch to VRSC")
 	rootCmd.Flags().Bool("no-tls-very-insecure", false, "run without the required TLS certificate, only for debugging, DO NOT use in production")
 	rootCmd.Flags().Bool("redownload", false, "re-fetch all blocks from zcashd; reinitialize local cache files")
 	rootCmd.Flags().String("data-dir", "/var/lib/lightwalletd", "data directory (such as db)")
@@ -283,6 +285,8 @@ func init() {
 	viper.SetDefault("log-level", int(logrus.InfoLevel))
 	viper.BindPFlag("log-file", rootCmd.Flags().Lookup("log-file"))
 	viper.SetDefault("log-file", "./server.log")
+	viper.BindPFlag("verusd-conf-path", rootCmd.Flags().Lookup("verusd-conf-path"))
+	viper.SetDefault("verusd-conf-path", "./VRSC.conf")
 	viper.BindPFlag("zcash-conf-path", rootCmd.Flags().Lookup("zcash-conf-path"))
 	viper.SetDefault("zcash-conf-path", "./zcash.conf")
 	viper.BindPFlag("no-tls-very-insecure", rootCmd.Flags().Lookup("no-tls-very-insecure"))

--- a/common/common.go
+++ b/common/common.go
@@ -29,6 +29,7 @@ type Options struct {
 	TLSKeyPath        string `json:"tls_cert_key,omitempty"`
 	LogLevel          uint64 `json:"log_level,omitempty"`
 	LogFile           string `json:"log_file,omitempty"`
+	VerusdConfPath    string `json:"verusd_conf,omitempty"`
 	ZcashConfPath     string `json:"zcash_conf,omitempty"`
 	NoTLSVeryInsecure bool   `json:"no_tls_very_insecure,omitempty"`
 	Redownload        bool   `json:"redownload"`

--- a/frontend/rpc_client.go
+++ b/frontend/rpc_client.go
@@ -11,7 +11,7 @@ import (
 	ini "gopkg.in/ini.v1"
 )
 
-func NewZRPCFromConf(confPath interface{}) (*rpcclient.Client, error) {
+func NewVRPCFromConf(confPath interface{}) (*rpcclient.Client, error) {
 	connCfg, err := connFromConf(confPath)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func connFromConf(confPath interface{}) (*rpcclient.ConnConfig, error) {
 	}
 	rpcport := cfg.Section("").Key("rpcport").String()
 	if rpcport == "" {
-		rpcport = "8232" // default mainnet
+		rpcport = "27486" // default mainnet
 		testnet, _ := cfg.Section("").Key("testnet").Int()
 		regtest, _ := cfg.Section("").Key("regtest").Int()
 		if testnet > 0 || regtest > 0 {
@@ -43,13 +43,13 @@ func connFromConf(confPath interface{}) (*rpcclient.ConnConfig, error) {
 	username := cfg.Section("").Key("rpcuser").String()
 	password := cfg.Section("").Key("rpcpassword").String()
 
-	// Connect to local Zcash RPC server using HTTP POST mode.
+	// Connect to local verusd RPC server using HTTP POST mode.
 	connCfg := &rpcclient.ConnConfig{
 		Host:         net.JoinHostPort(rpcaddr, rpcport),
 		User:         username,
 		Pass:         password,
-		HTTPPostMode: true, // Zcash only supports HTTP POST mode
-		DisableTLS:   true, // Zcash does not provide TLS by default
+		HTTPPostMode: true, // verusd only supports HTTP POST mode
+		DisableTLS:   true, // verusd does not provide TLS by default - wait, what?
 	}
 	// Notice the notification parameter is nil since notifications are
 	// not supported in HTTP POST mode.


### PR DESCRIPTION
Switch to VerusCoin, verusd & VRSC.conf.

VerusHash code is available but not yet used.

The current code has been switched to use verusd and the --verus-conf-file command line setting but it still does the old ZCash hash algorithm. Since this is the wrong for VRSC it gets stuck on the sapling enablement block flagging a reorg because the hashes do not match.

Next PR will use the VerusHash algorithms and properly detect the chain as not REORG. Coming soon.