### PR TITLE
Verushash v2b2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,9 @@ __debug_bin
 .vscode
 CMakeCache.txt
 Makefile
-
+.idea
+cert.*
+*.conf
 *.cmake
 *.log
 *.a

--- a/parser/block.go
+++ b/parser/block.go
@@ -36,14 +36,14 @@ func (b *Block) Transactions() []*Transaction {
 
 // GetDisplayHash returns the block hash in big-endian display order.
 func (b *Block) GetDisplayHash() []byte {
-	return b.hdr.GetDisplayHash(b.height)
+	return b.hdr.GetDisplayHash()
 }
 
 // TODO: encode hash endianness in a type?
 
 // GetEncodableHash returns the block hash in little-endian wire order.
-func (b *Block) GetEncodableHash(height int) []byte {
-	return b.hdr.GetEncodableHash(height)
+func (b *Block) GetEncodableHash() []byte {
+	return b.hdr.GetEncodableHash()
 }
 
 // GetDisplayPrevHash returns the prevHash field from b *Block
@@ -102,7 +102,7 @@ func (b *Block) ToCompact() *walletrpc.CompactBlock {
 		//TODO ProtoVersion: 1,
 		Height:   uint64(b.GetHeight()),
 		PrevHash: b.hdr.HashPrevBlock,
-		Hash:     b.GetEncodableHash(b.height),
+		Hash:     b.GetEncodableHash(),
 		Time:     b.hdr.Time,
 	}
 

--- a/parser/block.go
+++ b/parser/block.go
@@ -110,7 +110,7 @@ func (b *Block) ToCompact() *walletrpc.CompactBlock {
 	saplingTxns := make([]*walletrpc.CompactTx, 0, len(b.vtx))
 	for idx, tx := range b.vtx {
 		if tx.HasSaplingElements() {
-			saplingTxns = append(saplingTxns, tx.ToCompact(idx, b.height))
+			saplingTxns = append(saplingTxns, tx.ToCompact(idx))
 		}
 	}
 	compactBlock.Vtx = saplingTxns

--- a/parser/block_header.go
+++ b/parser/block_header.go
@@ -209,7 +209,7 @@ func parseNBits(b []byte) *big.Int {
 }
 
 // GetDisplayHash returns the bytes of a block hash in big-endian order.
-func (hdr *BlockHeader) GetDisplayHash(height int) []byte {
+func (hdr *BlockHeader) GetDisplayHash() []byte {
 	if hdr.cachedHash != nil {
 		return hdr.cachedHash
 	}
@@ -229,7 +229,7 @@ func (hdr *BlockHeader) GetDisplayHash(height int) []byte {
 }
 
 // GetEncodableHash returns the bytes of a block hash in little-endian wire order.
-func (hdr *BlockHeader) GetEncodableHash(height int) []byte {
+func (hdr *BlockHeader) GetEncodableHash() []byte {
 	serializedHeader, err := hdr.MarshalBinary()
 
 	if err != nil {

--- a/parser/block_header.go
+++ b/parser/block_header.go
@@ -222,7 +222,7 @@ func (hdr *BlockHeader) GetDisplayHash(height int) []byte {
 	// VerusHash
 	hash := make([]byte, 32)
 	ptrHash := uintptr(unsafe.Pointer(&hash[0]))
-	VerusHash.Anyverushash_reverse_height(string(serializedHeader), len(string(serializedHeader)), ptrHash, height)
+	VerusHash.Anyverushash_reverse(string(serializedHeader), len(string(serializedHeader)), ptrHash)
 
 	hdr.cachedHash = hash
 	return hdr.cachedHash
@@ -238,7 +238,7 @@ func (hdr *BlockHeader) GetEncodableHash(height int) []byte {
 
 	hash := make([]byte, 32)
 	ptrHash := uintptr(unsafe.Pointer(&hash[0]))
-	VerusHash.Anyverushash_height(string(serializedHeader), len(string(serializedHeader)), ptrHash, height)
+	VerusHash.Anyverushash(string(serializedHeader), len(string(serializedHeader)), ptrHash)
 
 	return hash
 }

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -273,7 +273,7 @@ type Transaction struct {
 }
 
 // GetDisplayHash returns the transaction hash in big-endian display order.
-func (tx *Transaction) GetDisplayHash(height int) []byte {
+func (tx *Transaction) GetDisplayHash() []byte {
 	if tx.txId != nil {
 		return tx.txId
 	}
@@ -287,7 +287,7 @@ func (tx *Transaction) GetDisplayHash(height int) []byte {
 }
 
 // GetEncodableHash returns the transaction hash in little-endian wire format order.
-func (tx *Transaction) GetEncodableHash(height int) []byte {
+func (tx *Transaction) GetEncodableHash() []byte {
 
 	hash := make([]byte, 32)
 	ptrHash := uintptr(unsafe.Pointer(&hash[0]))
@@ -307,7 +307,7 @@ func (tx *Transaction) HasSaplingElements() bool {
 func (tx *Transaction) ToCompact(index int, height int) *walletrpc.CompactTx {
 	ctx := &walletrpc.CompactTx{
 		Index: uint64(index), // index is contextual
-		Hash:  tx.GetEncodableHash(height),
+		Hash:  tx.GetEncodableHash(),
 		//Fee:     0, // TODO: calculate fees
 		Spends:  make([]*walletrpc.CompactSpend, len(tx.shieldedSpends)),
 		Outputs: make([]*walletrpc.CompactOutput, len(tx.shieldedOutputs)),

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -304,7 +304,7 @@ func (tx *Transaction) HasSaplingElements() bool {
 	return tx.version >= 4 && (len(tx.shieldedSpends)+len(tx.shieldedOutputs)) > 0
 }
 
-func (tx *Transaction) ToCompact(index int, height int) *walletrpc.CompactTx {
+func (tx *Transaction) ToCompact(index int) *walletrpc.CompactTx {
 	ctx := &walletrpc.CompactTx{
 		Index: uint64(index), // index is contextual
 		Hash:  tx.GetEncodableHash(),

--- a/parser/transaction.go
+++ b/parser/transaction.go
@@ -281,7 +281,7 @@ func (tx *Transaction) GetDisplayHash(height int) []byte {
 	// VerusHash
 	hash := make([]byte, 32)
 	ptrHash := uintptr(unsafe.Pointer(&hash[0]))
-	VerusHash.Anyverushash_reverse_height(string(tx.rawBytes), len(tx.rawBytes), ptrHash, height)
+	VerusHash.Anyverushash_reverse(string(tx.rawBytes), len(tx.rawBytes), ptrHash)
 	tx.txId = hash
 	return tx.txId
 }
@@ -292,7 +292,7 @@ func (tx *Transaction) GetEncodableHash(height int) []byte {
 	hash := make([]byte, 32)
 	ptrHash := uintptr(unsafe.Pointer(&hash[0]))
 
-	VerusHash.Anyverushash_height(string(tx.rawBytes), len(tx.rawBytes), ptrHash, height)
+	VerusHash.Anyverushash(string(tx.rawBytes), len(tx.rawBytes), ptrHash)
 	return hash
 }
 

--- a/parser/verushash/verushash.cxx
+++ b/parser/verushash/verushash.cxx
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <iostream>
 
 #include "include/verus_hash.h"
 
@@ -18,27 +19,15 @@ void Verushash::initialize() {
 
 void Verushash::anyverushash(const char * bytes, int length, void * hashresult) {
     if (bytes[0] == 4 and bytes[2] >= 1) {
-            if (bytes[2] < 3) {
-                verushash_v2b(bytes, length, hashresult);
-            } else {
+        if (length < 144 || bytes[143] < 3) {
+            verushash_v2b(bytes, length, hashresult);
+        } else {
+            if (bytes[143] < 4) {
                 verushash_v2b1(bytes, length, hashresult);
-            }
-    } else {
-                verushash(bytes, length, hashresult);
-    }
-}
-
-void Verushash::anyverushash_height(const char * bytes, int length, void * hashresult, int height) {
-    if (bytes[0] == 4 and bytes[2] >= 1) {
-            if (bytes[2] < 3) {
-                if (height > 800199) {
-                    verushash_v2b1(bytes, length, hashresult);
-                } else {
-                    verushash_v2b(bytes, length, hashresult);
-                }
             } else {
-                verushash_v2b1(bytes, length, hashresult);
+                verushash_v2b2(bytes, length, hashresult);
             }
+        }
     } else {
                 verushash(bytes, length, hashresult);
     }
@@ -46,31 +35,20 @@ void Verushash::anyverushash_height(const char * bytes, int length, void * hashr
 
 void Verushash::anyverushash_reverse(const char * bytes, int length, void * hashresult) {
     if (bytes[0] == 4 and bytes[2] >= 1) {
-            if (bytes[2] < 3) {
+        if (length < 144 || bytes[143] < 3) {
                 verushash_v2b_reverse(bytes, length, hashresult);
-            } else {
+        } else {
+            if (bytes[143] < 4) {
                 verushash_v2b1_reverse(bytes, length, hashresult);
+            } else {
+                verushash_v2b2_reverse(bytes, length, hashresult);
             }
+        }
     } else {
-            verushash_reverse(bytes, length, hashresult);
+        verushash_reverse(bytes, length, hashresult);
     }
 }
 
-void Verushash::anyverushash_reverse_height(const char * bytes, int length, void * hashresult, int height) {
-    if (bytes[0] == 4 and bytes[2] >= 1) {
-            if (bytes[2] < 3) {
-                if (height > 800199) {
-                    verushash_v2b1_reverse(bytes, length, hashresult);
-                } else {
-                    verushash_v2b_reverse(bytes, length, hashresult);
-                }
-            } else {
-                verushash_v2b1_reverse(bytes, length, hashresult);
-            }
-    } else {
-            verushash_reverse(bytes, length, hashresult);
-    }
-}
 
 void Verushash::verushash(const char * bytes, int length, void * hashresult) {
     initialize();

--- a/parser/verushash/verushash.go
+++ b/parser/verushash/verushash.go
@@ -44,28 +44,24 @@ typedef _gostring_ swig_type_10;
 typedef _gostring_ swig_type_11;
 typedef _gostring_ swig_type_12;
 typedef _gostring_ swig_type_13;
-typedef _gostring_ swig_type_14;
-typedef _gostring_ swig_type_15;
 extern void _wrap_Swig_free_verushash_c89415b43d900127(uintptr_t arg1);
 extern uintptr_t _wrap_Swig_malloc_verushash_c89415b43d900127(swig_intgo arg1);
 extern void _wrap_Verushash_initialized_set_verushash_c89415b43d900127(uintptr_t arg1, _Bool arg2);
 extern _Bool _wrap_Verushash_initialized_get_verushash_c89415b43d900127(uintptr_t arg1);
 extern void _wrap_Verushash_initialize_verushash_c89415b43d900127(uintptr_t arg1);
 extern void _wrap_Verushash_anyverushash_verushash_c89415b43d900127(uintptr_t arg1, swig_type_1 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_anyverushash_height_verushash_c89415b43d900127(uintptr_t arg1, swig_type_2 arg2, swig_intgo arg3, uintptr_t arg4, swig_intgo arg5);
-extern void _wrap_Verushash_anyverushash_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_3 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_anyverushash_reverse_height_verushash_c89415b43d900127(uintptr_t arg1, swig_type_4 arg2, swig_intgo arg3, uintptr_t arg4, swig_intgo arg5);
-extern void _wrap_Verushash_verushash_verushash_c89415b43d900127(uintptr_t arg1, swig_type_5 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_6 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_v2_verushash_c89415b43d900127(uintptr_t arg1, swig_type_7 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_v2_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_8 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_v2b_verushash_c89415b43d900127(uintptr_t arg1, swig_type_9 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_v2b_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_10 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_v2b1_verushash_c89415b43d900127(uintptr_t arg1, swig_type_11 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_v2b1_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_12 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_v2b2_verushash_c89415b43d900127(uintptr_t arg1, swig_type_13 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_verushash_v2b2_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_14 arg2, swig_intgo arg3, uintptr_t arg4);
-extern void _wrap_Verushash_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_15 arg2);
+extern void _wrap_Verushash_anyverushash_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_2 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_verushash_c89415b43d900127(uintptr_t arg1, swig_type_3 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_4 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_v2_verushash_c89415b43d900127(uintptr_t arg1, swig_type_5 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_v2_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_6 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_v2b_verushash_c89415b43d900127(uintptr_t arg1, swig_type_7 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_v2b_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_8 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_v2b1_verushash_c89415b43d900127(uintptr_t arg1, swig_type_9 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_v2b1_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_10 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_v2b2_verushash_c89415b43d900127(uintptr_t arg1, swig_type_11 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_verushash_v2b2_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_12 arg2, swig_intgo arg3, uintptr_t arg4);
+extern void _wrap_Verushash_reverse_verushash_c89415b43d900127(uintptr_t arg1, swig_type_13 arg2);
 extern uintptr_t _wrap_new_Verushash_verushash_c89415b43d900127(void);
 extern void _wrap_delete_Verushash_verushash_c89415b43d900127(uintptr_t arg1);
 #undef intgo
@@ -141,36 +137,12 @@ func (arg1 SwigcptrVerushash) Anyverushash(arg2 string, arg3 int, arg4 uintptr) 
 	}
 }
 
-func (arg1 SwigcptrVerushash) Anyverushash_height(arg2 string, arg3 int, arg4 uintptr, arg5 int) {
-	_swig_i_0 := arg1
-	_swig_i_1 := arg2
-	_swig_i_2 := arg3
-	_swig_i_3 := arg4
-	_swig_i_4 := arg5
-	C._wrap_Verushash_anyverushash_height_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_2)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3), C.swig_intgo(_swig_i_4))
-	if Swig_escape_always_false {
-		Swig_escape_val = arg2
-	}
-}
-
 func (arg1 SwigcptrVerushash) Anyverushash_reverse(arg2 string, arg3 int, arg4 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_anyverushash_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_3)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
-	if Swig_escape_always_false {
-		Swig_escape_val = arg2
-	}
-}
-
-func (arg1 SwigcptrVerushash) Anyverushash_reverse_height(arg2 string, arg3 int, arg4 uintptr, arg5 int) {
-	_swig_i_0 := arg1
-	_swig_i_1 := arg2
-	_swig_i_2 := arg3
-	_swig_i_3 := arg4
-	_swig_i_4 := arg5
-	C._wrap_Verushash_anyverushash_reverse_height_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_4)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3), C.swig_intgo(_swig_i_4))
+	C._wrap_Verushash_anyverushash_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_2)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -181,7 +153,7 @@ func (arg1 SwigcptrVerushash) Verushash(arg2 string, arg3 int, arg4 uintptr) {
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_5)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_3)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -192,7 +164,7 @@ func (arg1 SwigcptrVerushash) Verushash_reverse(arg2 string, arg3 int, arg4 uint
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_6)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_4)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -203,7 +175,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2(arg2 string, arg3 int, arg4 uintptr) 
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_v2_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_v2_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_5)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -214,7 +186,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2_reverse(arg2 string, arg3 int, arg4 u
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_v2_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_v2_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_6)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -225,7 +197,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2b(arg2 string, arg3 int, arg4 uintptr)
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_v2b_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_v2b_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -236,7 +208,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2b_reverse(arg2 string, arg3 int, arg4 
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_v2b_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_v2b_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -247,7 +219,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2b1(arg2 string, arg3 int, arg4 uintptr
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_v2b1_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_v2b1_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -258,7 +230,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2b1_reverse(arg2 string, arg3 int, arg4
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_v2b1_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_v2b1_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -269,7 +241,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2b2(arg2 string, arg3 int, arg4 uintptr
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_v2b2_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_v2b2_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -280,7 +252,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2b2_reverse(arg2 string, arg3 int, arg4
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	C._wrap_Verushash_verushash_v2b2_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
+	C._wrap_Verushash_verushash_v2b2_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2), C.uintptr_t(_swig_i_3))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -289,7 +261,7 @@ func (arg1 SwigcptrVerushash) Verushash_v2b2_reverse(arg2 string, arg3 int, arg4
 func (arg1 SwigcptrVerushash) Reverse(arg2 string) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_Verushash_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_1)))
+	C._wrap_Verushash_reverse_verushash_c89415b43d900127(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -313,9 +285,7 @@ type Verushash interface {
 	GetInitialized() (_swig_ret bool)
 	Initialize()
 	Anyverushash(arg2 string, arg3 int, arg4 uintptr)
-	Anyverushash_height(arg2 string, arg3 int, arg4 uintptr, arg5 int)
 	Anyverushash_reverse(arg2 string, arg3 int, arg4 uintptr)
-	Anyverushash_reverse_height(arg2 string, arg3 int, arg4 uintptr, arg5 int)
 	Verushash(arg2 string, arg3 int, arg4 uintptr)
 	Verushash_reverse(arg2 string, arg3 int, arg4 uintptr)
 	Verushash_v2(arg2 string, arg3 int, arg4 uintptr)

--- a/parser/verushash/verushash.h
+++ b/parser/verushash/verushash.h
@@ -13,9 +13,7 @@ public:
   bool initialized = false;
   void initialize();
   void anyverushash(const char * bytes, int length, void * hashresult);
-  void anyverushash_height(const char * bytes, int length, void * hashresult, int height);
   void anyverushash_reverse(const char * bytes, int length, void * hashresult);
-  void anyverushash_reverse_height(const char * bytes, int length, void * hashresult, int height);
   void verushash(const char * bytes, int length, void * hashresult);
   void verushash_reverse(const char * bytes, int length, void * hashresult);
   void verushash_v2(const char * bytes, int length, void * hashresult);

--- a/parser/verushash/verushash_wrap.cxx
+++ b/parser/verushash/verushash_wrap.cxx
@@ -325,29 +325,6 @@ void _wrap_Verushash_anyverushash_verushash_c89415b43d900127(Verushash *_swig_go
 }
 
 
-void _wrap_Verushash_anyverushash_height_verushash_c89415b43d900127(Verushash *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, void *_swig_go_3, intgo _swig_go_4) {
-  Verushash *arg1 = (Verushash *) 0 ;
-  char *arg2 = (char *) 0 ;
-  int arg3 ;
-  void *arg4 = (void *) 0 ;
-  int arg5 ;
-  
-  arg1 = *(Verushash **)&_swig_go_0; 
-  
-  arg2 = (char *)malloc(_swig_go_1.n + 1);
-  memcpy(arg2, _swig_go_1.p, _swig_go_1.n);
-  arg2[_swig_go_1.n] = '\0';
-  
-  arg3 = (int)_swig_go_2; 
-  arg4 = *(void **)&_swig_go_3; 
-  arg5 = (int)_swig_go_4; 
-  
-  (arg1)->anyverushash_height((char const *)arg2,arg3,arg4,arg5);
-  
-  free(arg2); 
-}
-
-
 void _wrap_Verushash_anyverushash_reverse_verushash_c89415b43d900127(Verushash *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, void *_swig_go_3) {
   Verushash *arg1 = (Verushash *) 0 ;
   char *arg2 = (char *) 0 ;
@@ -364,29 +341,6 @@ void _wrap_Verushash_anyverushash_reverse_verushash_c89415b43d900127(Verushash *
   arg4 = *(void **)&_swig_go_3; 
   
   (arg1)->anyverushash_reverse((char const *)arg2,arg3,arg4);
-  
-  free(arg2); 
-}
-
-
-void _wrap_Verushash_anyverushash_reverse_height_verushash_c89415b43d900127(Verushash *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2, void *_swig_go_3, intgo _swig_go_4) {
-  Verushash *arg1 = (Verushash *) 0 ;
-  char *arg2 = (char *) 0 ;
-  int arg3 ;
-  void *arg4 = (void *) 0 ;
-  int arg5 ;
-  
-  arg1 = *(Verushash **)&_swig_go_0; 
-  
-  arg2 = (char *)malloc(_swig_go_1.n + 1);
-  memcpy(arg2, _swig_go_1.p, _swig_go_1.n);
-  arg2[_swig_go_1.n] = '\0';
-  
-  arg3 = (int)_swig_go_2; 
-  arg4 = *(void **)&_swig_go_3; 
-  arg5 = (int)_swig_go_4; 
-  
-  (arg1)->anyverushash_reverse_height((char const *)arg2,arg3,arg4,arg5);
   
   free(arg2); 
 }


### PR DESCRIPTION
Clean things up, remove height plumbing that is not needed.
Works on prior hashes, but seems to work for the first v2b2 block only, fails from then on if I'm interpreting it properly.

Does seem to match functionality/results in verushashpy so I suspect I'm not assembling the hash input properly.